### PR TITLE
chore!: update eslint-plugin-vue peer dep version

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "eslint-plugin-import": "^2.22.1",
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-promise": "^4.2.1 || ^5.0.0",
-    "eslint-plugin-vue": "^7.0.0"
+    "eslint-plugin-vue": "^7.0.0 || ^8.0.0"
   },
   "peerDependenciesMeta": {
     "@vue/cli-service": {


### PR DESCRIPTION
This PR allow v8 of peer dependency `eslint-plugin-vue`.

I'm pretty sure this PR won't break anything, but I'm not certain. Someone with a lot more experience should check it before merging 😅 