### PR TITLE
Fix typo extens -> extends

### DIFF
--- a/packages/eslint-config-standard-with-typescript/README.md
+++ b/packages/eslint-config-standard-with-typescript/README.md
@@ -27,7 +27,7 @@ require("@rushstack/eslint-patch/modern-module-resolution")
 
 module.exports = {
   root: true,
-  extens: [
+  extends: [
     'plugin:vue/vue3-essential',
     '@vue/eslint-config-standard-with-typescript'
   ]
@@ -48,7 +48,7 @@ require("@rushstack/eslint-patch/modern-module-resolution")
 
 module.exports = {
   root: true,
-  extens: [
+  extends: [
     'plugin:vue/vue3-essential',
     '@vue/eslint-config-standard-with-typescript'
     '@vue/eslint-config-standard-with-typescript/allow-js-in-vue'
@@ -110,7 +110,7 @@ const createAliasSetting = require('@vue/eslint-config-standard-with-typescript/
 
 module.exports = {
   root: true,
-  extens: [
+  extends: [
     'plugin:vue/vue3-essential',
     '@vue/eslint-config-standard-with-typescript'
   ],


### PR DESCRIPTION
This fixes a typo in the eslint config samples, so that the extends property is spelt correctly.